### PR TITLE
I've updated the documentation to correct misleading performance clai…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ VexFS addresses the escalating demand for efficient, integrated storage solution
 
 ### ✅ **What's Working**
 - **Zero compilation errors** (resolved from 155 blocking errors)
-- **Functional vector operations** with performance benchmarking
+- **Functional vector operations** (tested via a userspace harness)
 - **Working C bindings** for userspace testing
 - **Vector test runner** demonstrating end-to-end functionality
-- **Performance validation**: 1000 vector insertions in ~2.3ms, searches in 2-5ms
 
 ### 🔧 **In Development**
 - VFS interface layer implementation
@@ -122,13 +121,13 @@ VexFS implements a layered architecture optimized for both traditional file I/O 
 ### Test Coverage
 - Unit tests for vector operations
 - Integration tests with VFS
-- Performance benchmarks
+- Preliminary performance benchmarks (userspace test harness)
 - POSIX compliance validation
 - Stress testing and data integrity checks
 
 ## Benchmarks
 
-Preliminary benchmarks of VexFS vector operations (kernel-native, using in-memory engine):
+Preliminary benchmarks using a userspace test harness (`vector_test_runner` with its internal `TestVectorSearchEngine`):
 
 ### ✅ Functional Test
 - 4 vectors added
@@ -136,14 +135,11 @@ Preliminary benchmarks of VexFS vector operations (kernel-native, using in-memor
 - File paths resolved correctly (`/test/vec1.bin`, `/test/vec4.bin`, etc.)
 
 ### ⚡ Performance Test
-- **1000 vectors inserted**: 2.26 ms
-- **Search (Euclidean)**: 10 nearest neighbors in 2.60 ms
-- **Search (Cosine)**: 10 nearest neighbors in 6.07 ms
-- **Search (Inner Product)**: 10 nearest neighbors in 2.22 ms
+The test harness performs these operations (1000 vector insertions, k-NN search for 3 metrics) in the order of milliseconds on typical desktop hardware. These figures serve as a baseline for the test harness itself.
 
-VexFS achieves vector search performance comparable to state-of-the-art userland vector databases, with zero syscall or network overhead. Search results include distance, score, and mapped file path for each vector match.
+The userspace test harness, by its nature, operates with low overhead. However, these results do not yet reflect the performance of the main VexFS kernel components or direct comparisons to production vector databases.
 
-> Functional and performance tests completed successfully on kernel-native implementation.
+> Functional and preliminary performance tests for the userspace test harness completed successfully.
 
 ## 🛣 **Roadmap**
 

--- a/docs/FUTURE_BENCHMARKING_STRATEGY.md
+++ b/docs/FUTURE_BENCHMARKING_STRATEGY.md
@@ -1,0 +1,32 @@
+# Future Benchmarking Strategy for VexFS
+
+To accurately assess and showcase the performance of VexFS, future benchmarking efforts should adhere to the following principles:
+
+1.  **Benchmark the Core Engine**:
+    *   Benchmarks must utilize the actual `VectorSearchEngine` (from `vexfs/src/vector_search.rs`) and its associated components, including `HnswGraph` (from `vexfs/src/anns/hnsw.rs`) for ANN searches and the `KnnSearchEngine`.
+    *   Avoid using the standalone `TestVectorSearchEngine` from `vexfs/src/vector_test.rs` for performance claims about VexFS itself. This test engine is suitable for basic functional checks or as a very simple baseline, but not for representing the performance of the main system.
+
+2.  **Accurate Timing Mechanisms**:
+    *   For benchmarks intended to run in userspace (e.g., testing the `vexfs` library components before full kernel integration), use reliable timing mechanisms like `std::time::Instant`.
+    *   If and when kernel-level benchmarks are developed, the `get_current_time_us()` function within `vexfs/src/vector_search.rs` (and similar timing functions) must be implemented to provide accurate, high-resolution timestamps from the kernel's perspective. Placeholder implementations should be replaced.
+
+3.  **Realistic Data Storage and Operations**:
+    *   The `TODO` comments and placeholder implementations in `vector_storage.rs` (and related modules like `file_ops.rs`, `dir_ops.rs` if they interact with vector data) need to be completed.
+    *   Benchmarks should reflect genuine data operations:
+        *   **Insertion**: This should involve the full pipeline of storing vector data, including any serialization, metadata updates, and index updates (e.g., adding nodes and edges to `HnswGraph`).
+        *   **Search**: This should involve querying the actual index and retrieving data through the storage layer.
+    *   Initially, an in-memory implementation of the `VectorStorageManager`'s backend could be used, but this should be clearly stated. The ultimate goal is to benchmark with persistence to a block device as expected of a file system.
+
+4.  **Implement Core Algorithms**:
+    *   Ensure that critical algorithms, like the layer assignment and search strategy in HNSW (`vexfs/src/anns/hnsw.rs`), are fully implemented according to established methods, replacing any simplified or placeholder logic.
+
+5.  **Clear Distinction in Reporting**:
+    *   Clearly differentiate between benchmarks for:
+        *   The userspace `vexfs` library (testing components outside the kernel).
+        *   The full VexFS kernel module (once integrated and testable within a VM).
+    *   Specify the environment, dataset size, vector dimensionality, hardware, and exact software configuration used for any published benchmarks.
+
+6.  **Comparative Benchmarks**:
+    *   Once VexFS is more mature, comparisons to other vector databases or search libraries should be done carefully, ensuring that the VexFS setup (userspace library or kernel module) is appropriate for the comparison being made.
+
+By following these guidelines, the VexFS project can build credible and informative performance metrics that accurately reflect its capabilities as it develops.


### PR DESCRIPTION
…ms and outline a benchmark strategy.

The performance benchmarks previously reported in README.md were based on a simplified test setup and didn't accurately reflect the capabilities of the main VexFS components.

Here's what I did:
- I modified README.md to remove the specific misleading performance figures and clarified that the current results are from the test setup.
- I added a new document, docs/FUTURE_BENCHMARKING_STRATEGY.md, to guide future benchmarking efforts for the core VexFS engine. This includes recommendations to use the actual VexFS components, implement accurate timing, ensure complete data storage functionalities, and clearly distinguish between different types of benchmarks.