### PR TITLE
fix: Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
@@ -132,7 +132,7 @@ jobs:
       run: cargo audit
 
     - name: Run cargo deny
-      uses: EmbarkStudios/cargo-deny-action@v1
+      uses: EmbarkStudios/cargo-deny-action@v2.0.11
 
   coverage:
     name: Code Coverage
@@ -182,7 +182,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -189,7 +189,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.30.0
       with:
         image-ref: ${{ matrix.image }}
         format: 'sarif'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
@@ -47,11 +47,11 @@ jobs:
 
     - name: Setup Pages
       if: github.ref == 'refs/heads/main'
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v4
 
     - name: Upload artifact
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: docs/user-guide/site
 
@@ -65,4 +65,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -59,7 +59,7 @@ jobs:
         fi
 
     - name: Build wheels
-      uses: PyO3/maturin-action@v1
+      uses: PyO3/maturin-action@v1.49.1
       with:
         target: ${{ matrix.target }}
         args: --release --out dist --find-interpreter
@@ -101,7 +101,7 @@ jobs:
         fi
 
     - name: Build sdist
-      uses: PyO3/maturin-action@v1
+      uses: PyO3/maturin-action@v1.49.1
       with:
         command: sdist
         args: --out dist
@@ -130,12 +130,12 @@ jobs:
       run: ls -la dist/
 
     - name: Publish to PyPI
-      uses: PyO3/maturin-action@v1
+      uses: PyO3/maturin-action@v1.49.1
       with:
         command: upload
         args: --non-interactive --skip-existing dist/*
       env:
-        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_AT }}
 
   publish-typescript-sdk:
     name: Publish TypeScript SDK
@@ -193,7 +193,7 @@ jobs:
       working-directory: bindings/typescript
       run: npm publish --access public
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AT }}
 
   verify-publications:
     name: Verify SDK Publications

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -162,7 +162,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run TruffleHog
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@v3.88.35
       with:
         path: ./
         base: main
@@ -327,7 +327,7 @@ jobs:
     steps:
     - name: Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v1
+      uses: dependabot/fetch-metadata@v2
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
This commit addresses issues with failing workflows and prepares for package publishing.

Key changes include:
- Updated secret names in `publish-sdks.yml` to use `NPM_AT` and `PYPI_AT` as you provided.
- Reviewed and confirmed `CARGO_REGISTRY_TOKEN` in `release.yml`.
- Updated versions of numerous third-party GitHub Actions across all workflow files (.github/workflows/*.yml) to their latest stable releases. This includes:
    - `actions/setup-python` to @v5
    - `actions/configure-pages` to @v4
    - `actions/upload-pages-artifact` to @v3
    - `actions/deploy-pages` to @v4
    - `dependabot/fetch-metadata` to @v2
    - `dtolnay/rust-toolchain` from @master to @stable
    - `aquasecurity/trivy-action` from @master to @0.30.0
    - `trufflesecurity/trufflehog` from @main to @v3.88.35
    - `PyO3/maturin-action` to @v1.49.1
    - `EmbarkStudios/cargo-deny-action` to @v2.0.11
- Reviewed version handling logic in `publish-sdks.yml` and `release.yml`; existing logic was found to be sound.

These changes aim to resolve existing workflow failures and ensure that the SDKs can be published correctly to npm and PyPi.